### PR TITLE
Add tox configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,5 @@ cover-package=airspeed
 cover-inclusive=1
 traverse-namespace=1
 detailed-errors=1
-with-id=1
 where=tests
 with-doctest=1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py{27,34}
+
+[testenv]
+deps =
+    coverage
+    nose
+usedevelop = True
+commands =
+    nosetests


### PR DESCRIPTION
Hi, 

I've added a simple tox config to make testing with different Python versions a little easier. It runs the tests with Python2.7 and Python3.4. 

To make tox work with the nose test runner, I had to get rid of the `with-id` option in the nosetests config (--with-id currently breaks the tests when run through tox. There's a fix for that in nose's master branch, but it hasn't been released yet). But given how fast the tests run I think `--with-id` isn't really needed anyway.

Cheers
Florian

