### PR TITLE
fix bug:

### DIFF
--- a/airspeed/api.py
+++ b/airspeed/api.py
@@ -25,7 +25,7 @@ class Airspeed(object):
     """
 
     def __init__(self, cache=10, **kw):
-        self.loaders = LRUCache(max_size=cache)
+        self.loaders = LRUCache(maxsize=cache)
 
     def __call__(self, data, template, mime_type="text/plain", **options):
         basepath = os.path.dirname(template)


### PR DESCRIPTION
pp Airspeed()({'bars': bars}, 'template.html')
*** TypeError: __init__() got an unexpected keyword argument 'max_size'

I'm using cachetools version 1.0.0