### PR TITLE
Add support for additional Java-like methods

### DIFF
--- a/tests/airspeed_test.py
+++ b/tests/airspeed_test.py
@@ -1112,6 +1112,21 @@ line")''')
         ns = {"end": 400}
         template.merge(ns)
 
+    def test_array_size(self):
+        template = airspeed.Template("#set($foo = [1,2,3]) $foo.size()")
+        output = template.merge({})
+        self.assertEquals(output, " 3")
+
+    def test_array_get_item(self):
+        template = airspeed.Template("#set($foo = [1,2,3]) $foo.get(1)")
+        output = template.merge({})
+        self.assertEquals(output, " 2")
+
+    def test_string_length(self):
+        template = airspeed.Template("#set($foo = 'foobar123') $foo.length()")
+        output = template.merge({})
+        self.assertEquals(output, " 9")
+
 # TODO:
 #
 #  Report locations for template errors in files included via loaders


### PR DESCRIPTION
@purcell Thanks for providing this awesome framework, it makes our life so much easier! Our main use case is creating local mocks for AWS API Gateway request templates.

This PR adds support for additional methods, to provide better compatibility with Java-based Velocity template implementations (e.g., AWS API Gateway).

In particular, this PR allows to call `size()` on objects of type `list`, and `length()` on objects of type `str`. Additional methods can be easily added to the configuration in the future.