### PR TITLE
Switched URL to point at the GitHub repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
                  "with the popular Velocity library for Java."),
     author="Steve Purcell and Chris Tarttelin",
     author_email="steve@pythonconsulting.com, chris@pythonconsulting.com",
-    url="http://dev.sanityinc.com/airspeed/wiki",
+    url="https://github.com/purcell/airspeed/",
     download_url="http://pypi.python.org/pypi/airspeed/",
     license="BSD",
     keywords='web.templating',


### PR DESCRIPTION
The existing URL doesn't exist, and https://www.sanityinc.com/software/ just tells users to come here anyway.