### PR TITLE
Implement additional methods `Map.put` and `Array.add`

### DIFF
--- a/airspeed/__init__.py
+++ b/airspeed/__init__.py
@@ -26,11 +26,14 @@ __all__ = [
 # result in calling method __additional_methods__[list]['size']($foo)
 __additional_methods__ = {
     str: {
-        'length': lambda *params: len(params[0])
+        'length': lambda self: len(self)
     },
     list: {
-        'size': lambda *params: len(params[0]),
-        'get': lambda *params: params[0][params[1]]
+        'size': lambda self: len(self),
+        'get': lambda self, index: self[index]
+    },
+    dict: {
+        'put': lambda self, key, value: self.update({key: value})
     }
 }
 

--- a/airspeed/__init__.py
+++ b/airspeed/__init__.py
@@ -30,7 +30,8 @@ __additional_methods__ = {
     },
     list: {
         'size': lambda self: len(self),
-        'get': lambda self, index: self[index]
+        'get': lambda self, index: self[index],
+        'add': lambda self, value: self.append(value)
     },
     dict: {
         'put': lambda self, key, value: self.update({key: value})

--- a/tests/airspeed_test.py
+++ b/tests/airspeed_test.py
@@ -1135,6 +1135,13 @@ line")''')
         output = template.merge({})
         self.assertEquals(output, " 9")
 
+    def test_dict_put_item(self):
+        template = airspeed.Template("#set( $ignore = $test_dict.put('k', 'new value') )"
+                                     "$test_dict.k")
+        output = template.merge({'test_dict': {'k': 'initial value'}})
+        self.assertEquals(output, "new value")
+
+
     def test_evaluate(self):
         template = airspeed.Template('''#set($source1 = "abc")
 #set($select = "1")

--- a/tests/airspeed_test.py
+++ b/tests/airspeed_test.py
@@ -1130,6 +1130,13 @@ line")''')
         output = template.merge({})
         self.assertEquals(output, " 2")
 
+    def test_array_add_item(self):
+        template = airspeed.Template("#set($foo = [1,2,3])"
+                                     "#set( $ignore = $foo.add('string value') )"
+                                     "#foreach($item in $foo)$item,#end")
+        output = template.merge({})
+        self.assertEquals(output, "1,2,3,string value,")
+
     def test_string_length(self):
         template = airspeed.Template("#set($foo = 'foobar123') $foo.length()")
         output = template.merge({})


### PR DESCRIPTION
Implement a common method Map.put (dict.put) to improve the compatibility with Apache Velocity.

@purcell I've also made other additional methods more explicit. Please let me know if you don't like it. I can put it back.

Issue #34 