### PR TITLE
Remove shebang & execute bit from __init__.py

### DIFF
--- a/airspeed/__init__.py
+++ b/airspeed/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 
 import re


### PR DESCRIPTION
There is no script-like content (“`if __name__ == '__main__'`”, etc.) and no apparent reason to execute it as a script rather than importing it.