### PR TITLE
Add support for #define template functions

### DIFF
--- a/airspeed/__init__.py
+++ b/airspeed/__init__.py
@@ -36,7 +36,8 @@ __additional_methods__ = {
         'add': lambda self, value: self.append(value)
     },
     dict: {
-        'put': lambda self, key, value: self.update({key: value})
+        'put': lambda self, key, value: self.update({key: value}),
+        'keySet': lambda self: self.keys()
     }
 }
 

--- a/airspeed/__init__.py
+++ b/airspeed/__init__.py
@@ -1029,7 +1029,8 @@ class MacroDefinition(_Element):
         'parse',
         'include',
         'stop',
-        'end')
+        'end',
+        'define')
 
     def parse(self):
         self.identity_match(self.START)
@@ -1104,6 +1105,35 @@ class MacroCall(_Element):
             raise Exception('no such macro: ' + self.macro_name)
         macro.execute_macro(stream, namespace, self.args, loader)
 
+class DefineDefinition(MacroDefinition):
+    START = re.compile(r'#define\b(.*)', re.S + re.I)
+    NAME = re.compile(r'\s*(\$[a-z][a-z_0-9]*)\b(.*)', re.S + re.I)
+
+    def evaluate_raw(self, stream, namespace, loader):
+        global_ns = namespace.top()
+        macro_key = self.macro_name.lower()
+        macro_key = macro_key.lstrip("$")
+        if macro_key in global_ns:
+            raise Exception("cannot redefine macro {0}".format(macro_key))
+
+        class ParamWrapper:
+            def __init__(self, value):
+                self.value = value
+
+            def calculate(self, namespace, loader):
+                return self.value
+
+        class ExecuteFunc:
+            def __call__(_self, *args, **kwargs):
+                args = [ParamWrapper(arg) for arg in args]
+                _stream = StoppableStream()
+                result = self.execute_macro(_stream, namespace, args, loader)
+                return _stream.getvalue()
+
+            def __repr__(self):
+                return self.__call__()
+
+        global_ns[macro_key] = ExecuteFunc()
 
 class IncludeDirective(_Element):
     START = re.compile(r'#include\b(.*)', re.S + re.I)
@@ -1258,6 +1288,7 @@ class Block(_Element):
                          IncludeDirective,
                          ParseDirective,
                          MacroDefinition,
+                         DefineDefinition,
                          StopDirective,
                          UserDefinedDirective,
                          EvaluateDirective,

--- a/tests/airspeed_test.py
+++ b/tests/airspeed_test.py
@@ -767,9 +767,11 @@ $email
     def test_use_defined_func_create_json_loop(self):
         template = airspeed.Template("""
         #define( $loop ) {
-            #foreach($e in $map.items())
-	           "$e[0]": "$e[1]"
-               #if( $foreach.hasNext ) , #end
+            #foreach($e in $map.keySet())
+                #set( $k = $e )
+                #set( $v = $map.get($k))
+                "$k": "$v"
+                #if( $foreach.hasNext ) , #end
             #end
         }
         #end

--- a/tests/airspeed_test.py
+++ b/tests/airspeed_test.py
@@ -741,6 +741,46 @@ $email
             '#macro (hello $value1 $value2 )hello $value1 and $value2#end\n#hello (1,\n 2)')
         self.assertEqual('hello 1 and 2', template.merge({}))
 
+    def test_use_define_with_no_parameters(self):
+        template = airspeed.Template('#define ( $hello)hi#end$hello()$hello()')
+        self.assertEqual('hihi', template.merge({}))
+
+    def test_use_define_with_parameters(self):
+        template = airspeed.Template('#define ( $echo $v1 $v2)$v1$v2#end$echo(1,"a")$echo("b",2)')
+        self.assertEqual('1ab2', template.merge({'text': 'hello'}))
+        template = airspeed.Template('#define ( $echo $v1 $v2)$v1$v2#end$echo(1,"a")$echo($echo(2,"b"),"c")')
+        self.assertEqual('1a2bc', template.merge({}))
+        template = airspeed.Template('#define ( $echo $v1 $v2)$v1$v2#end$echo(1,"a")$echo("b",$echo(3,"c"))')
+        self.assertEqual('1ab3c', template.merge({}))
+
+    def test_use_defined_func_multiple_times(self):
+        template = airspeed.Template("""
+            #define( $myfunc )$ctx#end
+            #set( $ctx = 'foo' )
+            $myfunc
+            #set( $ctx = 'bar' )
+            $myfunc
+        """)
+        result = template.merge({}).replace("\n", "").replace(" ", "")
+        self.assertEqual('foobar', result)
+
+    def test_use_defined_func_create_json_loop(self):
+        template = airspeed.Template("""
+        #define( $loop ) {
+            #foreach($e in $map.items())
+	           "$e[0]": "$e[1]"
+               #if( $foreach.hasNext ) , #end
+            #end
+        }
+        #end
+        $loop
+        #set( $map = {'foo':'bar'} )
+        $loop
+        """)
+        context = {"map": {"test": 123, "test2": "abc"}}
+        result = re.sub(r"\s", "", template.merge(context), flags=re.MULTILINE)
+        self.assertEqual('{"test":"123","test2":"abc"}{"foo":"bar"}', result)
+
     def test_include_directive_gives_error_if_no_loader_provided(self):
         template = airspeed.Template('#include ("foo.tmpl")')
         self.assertRaises(airspeed.TemplateError, template.merge, {})


### PR DESCRIPTION
Following up from https://github.com/purcell/airspeed/issues/55 - add support for `#define` template functions. Addresses https://github.com/localstack/localstack/issues/5587 

The implementation relies heavily on the existing `#macro` functionality, as @purcell suggested (thanks for laying out the solution, really helpful!).

Seems to cover the use case well, although there may still be a few things missing to achieve full compatibility with VLT (for use with AWS API Gateway). We can tackle those in a follow-up iteration, as needed.

If you have any suggestions on how to improve/optimize the implementation @purcell , please let us know! /cc @calvernaz